### PR TITLE
Solves #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Deploy kubeIP by running:
 kubectl apply -f deploy/.
 ```
 
+After assigning an IP address to a node kubeip will also crate a label for that node `kubip_assigned` with the value of the IP address (`.` are replaced with `_`) 
+
 # Deploy & Build From Source
 
 You need a Kubernetes 1.10 or newer cluster. You also need Docker and kubectl 1.10.x or newer installed on your machine, as well as the Google Cloud SDK. You can install the Google Cloud SDK (which also installs kubectl) [here](https://cloud.google.com/sdk).

--- a/pkg/compute/compute.go
+++ b/pkg/compute/compute.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	cfg "github.com/doitintl/kubeip/pkg/config"
 	"github.com/doitintl/kubeip/pkg/types"
+	"github.com/doitintl/kubeip/pkg/utils"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/compute/v1"
@@ -172,6 +173,7 @@ func replaceIP(projectID string, zone string, instance string, config *cfg.Confi
 	}
 	waitForComplition(projectID, zone, op)
 	logrus.WithFields(logrus.Fields{"pkg": "kubeip", "function": "replaceIP"}).Infof("Replaced IP for %s zone %s new ip %s", instance, zone, addr)
+	utils.TagNode(instance, addr)
 	return nil
 
 }
@@ -229,6 +231,6 @@ func Kubeip(instance <-chan types.Instance, config *cfg.Config) {
 	for {
 		inst := <-instance
 		logrus.WithFields(logrus.Fields{"pkg": "kubeip", "function": "Kubeip"}).Infof("Working on %s in zone %s", inst.Name, inst.Zone)
-		replaceIP(inst.ProjectID, inst.Zone, inst.Name, config)
+		replaceIP(inst.ProjectID, inst.Zone, inst.Name,config)
 	}
 }


### PR DESCRIPTION
After assigning an IP address to a node kubeip will also crate a label for that node `kubip_assigned` with the value of the IP address (`.` are replaced with `_`)