### PR TITLE
Remove old kubip_assigned tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# What is KubeIP?
+# What is KubeIP? [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=Google%20 Kubernetes%20Engine%20without%20 going%20NAT%20with%20kubeIP!%20&url=https://kubeip.com&via=avivl&hashtags=Kubernetes,GCP,GKE)
+[![License](https://img.shields.io/github/license/doitintl/kubeIP.svg)](LICENSE) [![GitHub stars](https://img.shields.io/github/stars/doitintl/kubeIP.svg?style=social&label=Stars&style=for-the-badge)](https://github.com/doitintl/kubeIP) [![Build Status](https://secure.travis-ci.org/doitintl/kubeIP.png?branch=master)](http://travis-ci.org/doitintl/kubeIP)
 
 Many applications need to be whitelisted by consumers based on source IP address. As of today, Google Kubernetes Engine doesn't support assigning a static pool of addresses to GKE cluster. kubeIP tries to solve this problem by assigning GKE nodes external IP addresses from a predefined list by continually watching the Kubernetes API for new/removed nodes and applying changes accordingly.
 

--- a/pkg/compute/compute.go
+++ b/pkg/compute/compute.go
@@ -173,6 +173,10 @@ func replaceIP(projectID string, zone string, instance string, config *cfg.Confi
 	}
 	waitForComplition(projectID, zone, op)
 	logrus.WithFields(logrus.Fields{"pkg": "kubeip", "function": "replaceIP"}).Infof("Replaced IP for %s zone %s new ip %s", instance, zone, addr)
+	oldNode, err := utils.GetNodeByIP(addr)
+	if err == nil {
+		utils.TagNode(oldNode, "0.0.0.0")
+	}
 	utils.TagNode(instance, addr)
 	return nil
 

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -23,6 +23,7 @@ package utils
 import (
 	"fmt"
 	"strings"
+	"errors"
 	"github.com/Sirupsen/logrus"
 	apps_v1 "k8s.io/api/apps/v1"
 	batch_v1 "k8s.io/api/batch/v1"
@@ -92,5 +93,23 @@ func TagNode(node string, ip string)  {
 	if err != nil {
 		logrus.Error(err)
 	}
+
+}
+
+func GetNodeByIP(ip string) (string, error){
+	kubeClient := GetClient()
+	dashIp := strings.Replace(ip, ".", "-", 4)
+	label := fmt.Sprintf("kubip_assigned=%v", dashIp)
+	l, err := kubeClient.CoreV1().Nodes().List(meta_v1.ListOptions{
+		LabelSelector: label,
+	})
+	if err != nil {
+		logrus.Error(err)
+		return "",err
+	}
+	if len(l.Items) == 0 {
+		return "",errors.New("Did not found matching node with IP")
+	}
+	return l.Items[0].GetName(), nil
 
 }


### PR DESCRIPTION
Before assigning kubip_assigned tag check and remove old entries that were using the same IP