### PR TITLE
 Do not crash when failing to list IP addresses

### DIFF
--- a/pkg/kipcompute/compute.go
+++ b/pkg/kipcompute/compute.go
@@ -129,6 +129,7 @@ func FindFreeAddress(projectID string, region string, config *cfg.Config) (strin
 	filter := "(labels." + config.LabelKey + "=" + config.LabelValue + ")"
 	addresses, err := computeService.Addresses.List(projectID, region).Filter("(status=RESERVED) AND " + filter).Do()
 	if err != nil {
+		logrus.WithFields(logrus.Fields{"pkg": "kubeip", "function": "FindFreeAddress"}).Errorf("Failed to list IP addresses in region %s: %q", region, err)
 		return "", err
 	}
 
@@ -155,7 +156,7 @@ func replaceIP(projectID string, zone string, instance string, config *cfg.Confi
 	computeService, err := compute.New(hc)
 	_, err = computeService.Instances.Get(projectID, zone, instance).Do()
 	if err != nil {
-		logrus.WithFields(logrus.Fields{"pkg": "kubeip", "function": "replaceIP"}).Infof("Instance not found %s zone %s", instance, zone)
+		logrus.WithFields(logrus.Fields{"pkg": "kubeip", "function": "replaceIP"}).Errorf("Instance not found %s zone %s: %q", instance, zone, err)
 		return err
 	}
 	op, err := computeService.Instances.DeleteAccessConfig(projectID, zone, instance, "external-nat", "nic0").Do()

--- a/pkg/kipcompute/compute.go
+++ b/pkg/kipcompute/compute.go
@@ -239,12 +239,11 @@ func Kubeip(instance <-chan types.Instance, config *cfg.Config) {
 	for {
 		inst := <-instance
 		logrus.WithFields(logrus.Fields{"pkg": "kubeip", "function": "Kubeip"}).Infof("Working on %s in zone %s", inst.Name, inst.Zone)
-		replaceIP(inst.ProjectID, inst.Zone, inst.Name,config)
+		replaceIP(inst.ProjectID, inst.Zone, inst.Name, config)
 	}
 }
 
-
-func IsAddressReserved (ip string, region string, projectID string) bool {
+func IsAddressReserved(ip string, region string, projectID string) bool {
 	ctx := context.Background()
 	hc, err := google.DefaultClient(ctx, container.CloudPlatformScope)
 	if err != nil {
@@ -264,7 +263,7 @@ func IsAddressReserved (ip string, region string, projectID string) bool {
 	}
 
 	if len(addresses.Items) != 0 {
-		logrus.WithFields(logrus.Fields{"pkg": "kubeip", "function": "IsAddressReserved"}).Infof("Node ip is reserved %s",ip)
+		logrus.WithFields(logrus.Fields{"pkg": "kubeip", "function": "IsAddressReserved"}).Infof("Node ip is reserved %s", ip)
 		return true
 	}
 	return false
@@ -286,12 +285,12 @@ func AddTagIfMissing(projectID string, instance string, zone string) {
 	var ip string
 	for _, config := range inst.NetworkInterfaces[0].AccessConfigs {
 		if config.NatIP != "" {
-			ip =  config.NatIP
+			ip = config.NatIP
 		}
 	}
-	if IsAddressReserved(ip,zone[:len(zone)-2],projectID) {
+	if IsAddressReserved(ip, zone[:len(zone)-2], projectID) {
 		logrus.WithFields(logrus.Fields{"pkg": "kubeip", "function": "AddTagIfMissing"}).Infof("Tagging %s", instance)
-		utils.TagNode(instance,ip)
+		utils.TagNode(instance, ip)
 	}
 
 }

--- a/pkg/kipcompute/compute.go
+++ b/pkg/kipcompute/compute.go
@@ -127,7 +127,11 @@ func FindFreeAddress(projectID string, region string, config *cfg.Config) (strin
 		return "", err
 	}
 	filter := "(labels." + config.LabelKey + "=" + config.LabelValue + ")"
-	addresses, _ := computeService.Addresses.List(projectID, region).Filter("(status=RESERVED) AND " + filter).Do()
+	addresses, err := computeService.Addresses.List(projectID, region).Filter("(status=RESERVED) AND " + filter).Do()
+	if err != nil {
+		return "", err
+	}
+
 	if len(addresses.Items) != 0 {
 		return addresses.Items[0].Address, nil
 	}


### PR DESCRIPTION
This PR avoids a panic at https://github.com/doitintl/kubeIP/blob/8cac64b/pkg/kipcompute/compute.go#L131
when kubeip failed to list addresses.

This can occur when IAM permissions are missing.

Logging the error message helps troubleshooting that issue.