### PR TITLE
Panic in case of error when requesting local metadata API

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,11 +35,13 @@ func main() {
 	config, _ = cfg.NewConfig()
 	cluster, err := kipcompute.ClusterName()
 	if err != nil {
-		logrus.Info(err)
+		logrus.Fatal(err)
+		panic(err)
 	}
 	projectID, err := kipcompute.ProjectName()
 	if err != nil {
-		logrus.Info(err)
+		logrus.Fatal(err)
+		panic(err)
 	}
 	logrus.WithFields(logrus.Fields{
 		"Cluster name": cluster,
@@ -47,5 +49,9 @@ func main() {
 		"Version":      version,
 		"Build Date":   build_date,
 	}).Info("kubeIP is starting")
-	c.Run(config)
+	err = c.Run(config)
+	if err != nil {
+		logrus.Fatal(err)
+		panic(err)
+	}
 }

--- a/pkg/client/run.go
+++ b/pkg/client/run.go
@@ -25,6 +25,6 @@ import (
 	"github.com/doitintl/kubeip/pkg/controller"
 )
 
-func Run(config *cfg.Config) {
-	controller.Start(config)
+func Run(config *cfg.Config) error {
+	return controller.Start(config)
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -74,7 +74,7 @@ const maxRetries = 5
 
 const prefix = "kube-system/kube-proxy-"
 
-func Start(config *cfg.Config) {
+func Start(config *cfg.Config) error {
 	var kubeClient kubernetes.Interface
 	_, err := rest.InClusterConfig()
 	if err != nil {
@@ -100,10 +100,12 @@ func Start(config *cfg.Config) {
 	c.projectID, err = kipcompute.ProjectName()
 	if err != nil {
 		logrus.Fatal(err)
+		return err
 	}
 	c.clusterName, err = kipcompute.ClusterName()
 	if err != nil {
 		logrus.Fatal(err)
+		return err
 	}
 	c.config = config
 	c.ticker = time.NewTicker(5 * time.Minute)
@@ -120,6 +122,7 @@ func Start(config *cfg.Config) {
 	signal.Notify(sigterm, syscall.SIGINT)
 	<-sigterm
 
+	return nil
 }
 
 func newResourceController(client kubernetes.Interface, informer cache.SharedIndexInformer, resourceType string) *Controller {
@@ -326,7 +329,7 @@ func (c *Controller) assignMissingTags() {
 				logrus.Fatalf("Could not get authenticated client: %v", err)
 				continue
 			}
-			logrus.WithFields(logrus.Fields{"pkg": "kubeip", "function": "assignMissingTags"}).Infof("Found node without tag %s",node.GetName())
+			logrus.WithFields(logrus.Fields{"pkg": "kubeip", "function": "assignMissingTags"}).Infof("Found node without tag %s", node.GetName())
 			kipcompute.AddTagIfMissing(c.projectID, node.GetName(), nodeZone)
 
 		} else {


### PR DESCRIPTION
When Kubeip fails to retrieve instance metadata, it logs the issue and continues its execution as if everything was normal: 
https://github.com/doitintl/kubeIP/blob/8cac64bd18319d5eda3e0f4755ee4dd69baed969/main.go#L38
https://github.com/doitintl/kubeIP/blob/8cac64bd18319d5eda3e0f4755ee4dd69baed969/main.go#L42
https://github.com/doitintl/kubeIP/blob/a2b81b0bd904689fb5f966b35a80b15d92fd0a9a/pkg/controller/controller.go#L102

I only witnessed this once so far during the upgrade of GKE nodes: kubeip was evicted from a node that was being drained and rescheduled on a node freshly replaced.

Here's its output of the affected container that started at 2018-09-25T09:36:11Z :

```
time="2018-09-25T09:36:41Z" level=info msg="Get http://metadata/computeMetadata/v1/instance/attributes/cluster-name: dial tcp: i/o timeout"
time="2018-09-25T09:37:11Z" level=info msg="Get http://metadata.google.internal/computeMetadata/v1/project/project-id: dial tcp: i/o timeout"
time="2018-09-25T09:37:11Z" level=info msg="kubeIP is starting" Build Date="2018-09-03-10:53" Cluster name= Project name= Version=ba2645191920675f89f59b81da45936a0633f97b
time="2018-09-25T09:37:41Z" level=fatal msg="Get http://metadata.google.internal/computeMetadata/v1/project/project-id: dial tcp: i/o timeout"
```

Please notice the 30s interval between log messages corresponding to the timeout of metadata API requests.

At 2018-09-25T09:37:42Z, the container was terminated in Error status.

The last message logged by the container before its termination is from https://github.com/doitintl/kubeIP/blob/a2b81b0bd904689fb5f966b35a80b15d92fd0a9a/pkg/controller/controller.go#L102
it did not log an error on https://github.com/doitintl/kubeIP/blob/a2b81b0bd904689fb5f966b35a80b15d92fd0a9a/pkg/controller/controller.go#L106
so the call https://github.com/doitintl/kubeIP/blob/a2b81b0bd904689fb5f966b35a80b15d92fd0a9a/pkg/controller/controller.go#L104
probably succeeded.

Also, this was not logged:
https://github.com/doitintl/kubeIP/blob/a2b81b0bd904689fb5f966b35a80b15d92fd0a9a/pkg/controller/controller.go#L153

When a new container was started for the same pod after that, it was working normally.

I still have not explained:
- why a timeout occurred when kubeip tried to access the local metadata API. It should not be a DNS issue, as its hard-coded to 169.254.169.254 in `/etc/hosts`.
- why the kubeip container was terminated without any additional log message.

This PR makes kubeip panic if it fails to query the metadata API as this most certainly indicates the container is suffering of other big issues.
The container would have been terminated after the first timeout, at 30s, instead of 1m30s.

**Additional context**

- GKE nodes upgrade from 1.8.12-gke.1 to 1.9.7-gke.6
- COS image gke-197-gke6-cos-stable-65-10323-99-0-p2-v180816-pre
- Network Policy with Calico enabled