### PR TITLE
Changed GCP_REGION example from us-central1 to us-central1-b

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ gcloud config set project {your project_id}
 Set the environment variables: 
  
  ```
-export GCP_REGION=us-central1
+export GCP_REGION=us-central1-b
 export GKE_CLUSTER_NAME=kubeip-cluster
 export PROJECT_ID=$(gcloud config list --format 'value(core.project)')
 export KUBEIP_SELF_NODEPOOL=pool-kubip


### PR DESCRIPTION
Running the onboarding example as is, I got a

```
$ gcloud container clusters get-credentials $GKE_CLUSTER_NAME --region $GCP_REGION --project $PROJECT_ID
Fetching cluster endpoint and auth data.
ERROR: (gcloud.container.clusters.get-credentials) ResponseError: code=404, message=Not found: projects/prismatic-canto-133623/locations/us-central1/clusters/cluster-1.
Could not find [cluster-1] in [us-central1].
Did you mean [cluster-1] in [us-central1-b]?```

The right value should be us-central1-b