### PR TITLE
Add support for monitoring all node pools

### DIFF
--- a/deploy/kubeip-configmap.yaml
+++ b/deploy/kubeip-configmap.yaml
@@ -6,6 +6,7 @@ data:
   KUBEIP_FORCEASSIGNMENT: "true"
   KUBEIP_ADDITIONALNODEPOOLS: ""
   KUBEIP_TICKER: "5"
+  KUBEIP_ALLNODEPOOLS: "false"
 kind: ConfigMap
 metadata:
   labels:

--- a/deploy/kubeip-deployment.yaml
+++ b/deploy/kubeip-deployment.yaml
@@ -58,6 +58,12 @@ spec:
               configMapKeyRef:
                 key: "KUBEIP_TICKER"
                 name: "kubeip-config"
+          - name: "KUBEIP_ALLNODEPOOLS"
+            valueFrom:
+              configMapKeyRef:
+                key: "KUBEIP_ALLNODEPOOLS"
+                name: "kubeip-config"
+
 
 
           - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	ForceAssignment bool
 	AdditionalNodePools[] string
 	Ticker time.Duration
+	AllNodePools bool
 }
 
 func setConfigDefaults() {
@@ -44,6 +45,7 @@ func setConfigDefaults() {
 	viper.SetDefault("ForceAssignment", true)
 	viper.SetDefault("AdditionalNodePools", "")
 	viper.SetDefault("Ticker", 5)
+	viper.SetDefault("AllNodePools", false)
 }
 
 func NewConfig() (*Config, error) {
@@ -63,6 +65,7 @@ func NewConfig() (*Config, error) {
 		ForceAssignment: viper.GetBool("forceassignment"),
 		AdditionalNodePools: AdditionalNodePools,
 		Ticker:           viper.GetDuration("ticker"),
+		AllNodePools: viper.GetBool("allnodepools"),
 	}
 	return &c, nil
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -209,6 +209,9 @@ func (c *Controller) processNextItem() bool {
 }
 
 func (c *Controller) isNodePollMonitored(pool string) bool {
+	if c.config.AllNodePools == true {
+		return true
+	}
 	if strings.ToLower(pool) == strings.ToLower(c.config.NodePool) {
 		return true
 	}


### PR DESCRIPTION
A new variable AllNodePools was introduced. Defaults to False. Once set
to true all node pools in the cluster will be monitored  and will get an
available static ip from the pool
Fixes #52