### PR TITLE
Fix Kubeip not replacing IPs if node's access config name != external-nat

### DIFF
--- a/pkg/kipcompute/compute.go
+++ b/pkg/kipcompute/compute.go
@@ -118,12 +118,13 @@ func replaceIP(projectID string, zone string, instance string, pool string, conf
 	}
 	logrus.WithFields(logrus.Fields{"pkg": "kubeip", "function": "replaceIP"}).Infof("Found reserved address %s", addr)
 	computeService, err := compute.New(hc)
-	_, err = computeService.Instances.Get(projectID, zone, instance).Do()
+	inst, err := computeService.Instances.Get(projectID, zone, instance).Do()
 	if err != nil {
 		logrus.WithFields(logrus.Fields{"pkg": "kubeip", "function": "replaceIP"}).Errorf("Instance not found %s zone %s: %q", instance, zone, err)
 		return err
 	}
-	op, err := computeService.Instances.DeleteAccessConfig(projectID, zone, instance, "external-nat", "nic0").Do()
+	accessConfigName := inst.NetworkInterfaces[0].AccessConfigs[0].Name
+	op, err := computeService.Instances.DeleteAccessConfig(projectID, zone, instance, accessConfigName, "nic0").Do()
 	if err != nil {
 		logrus.Errorf("DeleteAccessConfig %q", err)
 		return err


### PR DESCRIPTION
The steps that Kubeip follows to replace an ephemeral IP with an
external IP on a given node, among others, are:
* Delete the node's access config called 'external-nat'.
* Create a new access config for the node with a free external IP.

If the node's access config has a name different than 'external-nat', it
doesn't get deleted and, when attempting to add another access config with
the external IP, the GCloud API returns a 400:

"googleapi: Error 400: At most one access config currently supported.
badRequest"

To work this around, instead of assuming that the access config will be
called 'external-nat', actively retrieve the access config name and use
this retrieved name to issue the DeleteAccessConfig request.