### PR TITLE
Fix documentation of kubip_assigned value

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ Deploy kubeIP by running:
 kubectl apply -f deploy/.
 ```
 
-Once you’ve assigned an IP address to a node kubeIP, a label will be created for that node `kubip_assigned` with the value of the IP address (`.` are replaced with `_`):
+Once you’ve assigned an IP address to a node kubeIP, a label will be created for that node `kubip_assigned` with the value of the IP address (`.` are replaced with `-`):
 
- `172.31.255.255 ==> 172_31_255_255`
+ `172.31.255.255 ==> 172-31-255-255`
 
 
 # Deploy & Build From Source


### PR DESCRIPTION
It should be dashes instead of underscores, see:

https://github.com/doitintl/kubeip/blob/c9c0b1d25510f25e55c6db6497b5bc7eac719a9c/pkg/utils/k8sutil.go#L89-L90