### PR TITLE
chore: bump runner from ubuntu 18.04 -> 20.04

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
 
   docker-build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
     steps:


### PR DESCRIPTION
This PR attempts to help resolve CI/CD errors in the existing `.github/workflows/build.yaml` file that are preventing the `docker-build` step from running on new PRs from the community or dependabot when it bumps version dependencies due to security issues.

<img width="1617" alt="Screenshot 2023-03-21 at 09 53 40" src="https://user-images.githubusercontent.com/2589943/226628873-0db5ceaf-9323-4964-9273-95a6429b8fef.png">

https://github.com/actions/runner-images/issues/6002