### PR TITLE
fix: deprecated gh actions functions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,6 +67,7 @@ jobs:
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
 
       - name: login to DockerHub
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,10 +64,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "push" ]; then
             TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
           fi
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
-          FORMATTED_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-          echo "created=$FORMATTED_DATE" >> $GITHUB_OUTPUT
 
       - name: login to DockerHub
         uses: docker/login-action@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,14 +24,14 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: set up Docker buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           version: latest
 
@@ -69,14 +69,14 @@ jobs:
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
       - name: login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
             push: ${{ github.event_name != 'pull_request' }}
             platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
   docker-build:
 
     runs-on: ubuntu-20.04
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    if: ${{ !contains(github.event.head_commit.message,'[skip ci]') }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,9 +64,10 @@ jobs:
           elif [ "${{ github.event_name }}" = "push" ]; then
             TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
           fi
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          FORMATTED_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo "created=$FORMATTED_DATE" >> $GITHUB_OUTPUT
 
       - name: login to DockerHub
         uses: docker/login-action@v2


### PR DESCRIPTION
This attempts to resolve https://github.com/doitintl/kubeip/issues/96. Most of these [errors](https://github.com/doitintl/kubeip/actions/runs/4486570177) being surfaced were coming from outdated Actions such as docker/login-action or docker/build-push-action. I've updated their major semantic versions to the latest available which should eliminate most errors. There were a couple related to us using `set-output` within the `id: prep` step in our build.yaml Workflow itself. I've removed the outputs that are not consumed (date, version) and converted the `tags` output var to utilize the newer style of `echo "tags=${TAGS}" >> $GITHUB_OUTPUT`.