### PR TITLE
chore: bump Go to 1.20 to resolve CVE-2023-29405, CVE-2023-29404 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
 
   docker-build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: ${{ !contains(github.event.head_commit.message,'[skip ci]') }}
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # ----- Go Builder Image ------
 #
-FROM golang:1.17-alpine AS builder
+FROM golang:1.20-alpine AS builder
 # curl git bash
 RUN apk add --no-cache curl git bash make
 #

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/doitintl/kubeip
 
-go 1.17
+go 1.20
 
 require (
 	cloud.google.com/go v0.97.0


### PR DESCRIPTION
This PR aims to resolve two recent CVEs that are related and each has a score of 9.8.

* https://nvd.nist.gov/vuln/detail/CVE-2023-29405
* https://nvd.nist.gov/vuln/detail/CVE-2023-29404

Both publications indicate that updating to Go 1.20.5 or later will resolve the vulnerability finding in our container scanning solution. I have updated the `Dockerfile` and `go.mod` to reflect this change. Running `make test` and `make image` locally yields no test failures or build issues.

I have also taken the opportunity to bump the `build.yml` GH Action to utilize the newer Ubuntu 22.04 LTS image over the older Ubuntu 20.04 option to keep things fresh.