### PR TITLE
fix/replace-ip/node-not-ready

### DIFF
--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -233,6 +233,7 @@ func WaitForNodeReady(node string, timeout time.Duration) error {
 			if isNodeReady(n.Status.Conditions) {
 				return nil
 			}
+			logrus.WithFields(logrus.Fields{"pkg": "kubeip", "function": "waitForNodeReady"}).Infof("waiting for node %s to be ready", node)
 			time.Sleep(5 * time.Second)
 		}
 	}


### PR DESCRIPTION
fixes #110

- fix timing conflict
- new node is added to the cluster but is not ready yet
- kubeip runs and replaces node ip
- node ip bootstrap interrupted and node remains in Not Ready status