### PR TITLE
Fix stripping zones from GCP regions

### DIFF
--- a/internal/address/gcp.go
+++ b/internal/address/gcp.go
@@ -99,8 +99,8 @@ func NewGCPAssigner(ctx context.Context, logger *logrus.Entry, project, region s
 			return nil, errors.Wrap(err, "failed to get region from metadata server")
 		}
 		// if cluster-location is zone, extract region from zone
-		if len(region) > 3 && region[len(region)-3] == '-' {
-			region = region[:len(region)-3]
+		if len(region) > 2 && region[len(region)-2] == '-' {
+			region = region[:len(region)-2]
 		}
 	}
 


### PR DESCRIPTION
Me and @MikeW1901 believe this should fix #127

To demonstrate, here's a quite script to test the stripping:

```go
package main

import "fmt"

func old() {
        region := "us-central1-a"
        if len(region) > 3 && region[len(region)-3] == '-' {
            region = region[:len(region)-3]
        }
        fmt.Printf("Old: %s\n", region)
}

func new() {
	region := "us-central1-a"
	if len(region) > 2 && region[len(region)-2] == '-' {
            region = region[:len(region)-2]
        }
	fmt.Printf("New: %s\n", region)
}

func main() {
	old()
	new()
}
```

Which outputs:
```
Old: us-central1-a
New: us-central1
```